### PR TITLE
added batchnorm to simclr projection head (same as in main simclr repo)

### DIFF
--- a/patchwork/feature/_simclr.py
+++ b/patchwork/feature/_simclr.py
@@ -99,8 +99,11 @@ def _build_embedding_model(fcn, imshape, num_channels, num_hidden, output_dim):
         inpt = [inpt0, inpt1]
     net = fcn(inpt)
     net = tf.keras.layers.Flatten()(net)
-    net = tf.keras.layers.Dense(num_hidden, activation="relu")(net)
-    net = tf.keras.layers.Dense(output_dim)(net)
+    net = tf.keras.layers.Dense(num_hidden)(net)
+    net = tf.keras.layers.BatchNormalization()(net)
+    net = tf.keras.layers.Activation("relu")(net)
+    net = tf.keras.layers.Dense(output_dim, use_bias=False)(net)
+    net = tf.keras.layers.BatchNormalization()(net)
     embedding_model = tf.keras.Model(inpt, net)
     return embedding_model
 

--- a/patchwork/tests/test_feature_simclr.py
+++ b/patchwork/tests/test_feature_simclr.py
@@ -95,7 +95,7 @@ def test_build_embedding_model():
     model = _build_embedding_model(fcn, (32,32), 3, 17, 11)
     assert isinstance(model, tf.keras.Model)
     assert model.output_shape[-1] == 11
-    assert len(model.layers) == 5
+    assert len(model.layers) == 8
     
     
 def test_build_simclr_training_step():


### PR DESCRIPTION
I'm not seeing a huge effect in the tests I've done so far, but the projection head now has batch normalization (and disabled bias in the final layer) consistent with the [SimCLR repo](https://github.com/google-research/simclr/blob/81e63a27be8b400a268cd4e1710af7590d172a36/model_util.py#L141).

I got to thinking about this after reading an interesting [blog post](https://untitled-ai.github.io/understanding-self-supervised-contrastive-learning.html) on the BYOL algorithm, that makes a compelling case that the BN layers in BYOL might be making it implicitly contrastive.