### PR TITLE
Alignment

### DIFF
--- a/patchwork/_util.py
+++ b/patchwork/_util.py
@@ -1,5 +1,6 @@
 import numpy as np
 from PIL import Image
+from scipy.spatial.distance import cdist
 
 import tensorflow as tf
 
@@ -96,3 +97,32 @@ def compute_l2_loss(*models):
                 loss += tf.nn.l2_loss(v)
                 
     return loss
+
+
+def _compute_alignment_and_uniformity(dataset, model, alpha=2, t=2):
+    """
+    Compute measures from "Understanding Contrastive Representation Learning
+    Through Alignment and Uniformity on the Hypersphere" by Wang and Isola.
+    
+    :dataset: tensorflow dataset returning augmented pairs of images
+    :model: keras model mapping images to semantic vectors (NOT the fully 
+              convolutional network!)
+    :alpha: parameter for alignment
+    :t: parameter for uniformity
+    
+    Returns alignment, uniformity
+    """
+    batch_alignment = []
+    vectors = []
+    for x1,x2 in dataset:
+        # compute normalized embedding vectors for each
+        z1 = tf.nn.l2_normalize(model(x1), axis=1)
+        z2 = tf.nn.l2_normalize(model(x2), axis=1)
+        batch_alignment.append(tf.reduce_sum((z1-z2)**alpha, axis=1).numpy())
+        vectors.append(z1.numpy())
+
+    alignment = np.concatenate(batch_alignment, axis=0).mean()
+
+    vectors = np.concatenate(vectors, axis=0)
+    uniformity = np.log(np.mean(np.exp(-1*t*cdist(vectors, vectors, metric="euclidean"))))
+    return alignment, uniformity

--- a/patchwork/feature/_generic.py
+++ b/patchwork/feature/_generic.py
@@ -261,7 +261,8 @@ class GenericExtractor(object):
         for h in hists:
             tf.summary.histogram(h, hists[h], step=self.step)
             
-    def _linear_classification_test(self, params=None):
+    def _linear_classification_test(self, params=None, 
+                                    metrics=["linear_classification_accuracy"]):
          acc, conf_mat = linear_classification_test(self.fcn, 
                                     self._downstream_labels, 
                                     **self.input_config)
@@ -274,9 +275,10 @@ class GenericExtractor(object):
          if params is not None:
              # first time- set up hparam config
              if not hasattr(self, "_hparams_config"):
+                metrics = [hp.Metric(m) for m in metrics]
                 self._hparams_config = hp.hparams_config(
                         hparams=list(params.keys()), 
-                        metrics=[hp.Metric("linear_classification_accuracy")])
+                        metrics=metrics)
                 
                 # record hyperparamters
                 base_dir, run_name = os.path.split(self.logdir)

--- a/patchwork/tests/test_util.py
+++ b/patchwork/tests/test_util.py
@@ -3,7 +3,7 @@ import numpy as np
 import tensorflow as tf
 
 from patchwork._util import shannon_entropy, tiff_to_array, _load_img
-from patchwork._util import compute_l2_loss
+from patchwork._util import compute_l2_loss, _compute_alignment_and_uniformity
 
 
 
@@ -106,3 +106,17 @@ def test_l2_loss():
     model = tf.keras.Model(inpt,net)
     assert compute_l2_loss(model).numpy() == 0.
     
+    
+def test_compute_alignment_and_uniformity():
+    X = np.random.normal(0,1, size=(32,16)).astype(np.float32)
+    ds = tf.data.Dataset.from_tensor_slices((X,X))
+    ds = ds.batch(8)
+
+    inpt = tf.keras.layers.Input((16,))
+    net = tf.keras.layers.Dense(2)(inpt)
+    mod = tf.keras.Model(inpt,net)
+    
+    al, un = _compute_alignment_and_uniformity(ds, mod)
+    
+    assert al >= 0
+    assert un <= 0


### PR DESCRIPTION
Added alignment and uniformity calculations to SimCLR and MoCo. Estimates are made from `testdata`.

The calculations are made at the end of each epoch and are recorded to TensorBoard both as scalars and as HPARAMS metrics.

Closes #62 