### PR TITLE
Global Response Normalization for Convnext

### DIFF
--- a/patchwork/_badge.py
+++ b/patchwork/_badge.py
@@ -36,7 +36,7 @@ class KPlusPlusSampler():
         self.d = X.shape[1]
         # create boolean array of length N indicating which
         # indices are available for sampling
-        self.available = np.ones(self.N).astype(np.bool)
+        self.available = np.ones(self.N).astype(bool)
         if indices is not None:
             for i in indices:
                 self.available[i] = False

--- a/patchwork/_convnext.py
+++ b/patchwork/_convnext.py
@@ -3,6 +3,10 @@ import tensorflow as tf
 
 
 _channels = {
+    "A":(40, 80, 160, 320), #v2 atto
+    "F":(48, 96, 192, 384), #v2 femto
+    "P":(64, 128, 256, 512), #v2 pico
+    "N":(80, 160, 320, 640), #v2 nano
     "T":(96, 192, 384, 768),
     "S": (96, 192, 384, 768),
     "B":(128, 256, 512, 1024),
@@ -11,6 +15,10 @@ _channels = {
 }
 
 _blocks = {
+    "A":(2, 2, 6, 2),
+    "F":(2, 2, 6, 2),
+    "P":(2, 2, 6, 2),
+    "N":(2, 2, 8, 2),
     "T":(3, 3, 9, 3),
     "S":(3, 3, 27, 3),
     "B":(3, 3, 27, 3),
@@ -18,8 +26,53 @@ _blocks = {
     "XL":(3, 3, 27, 3)
 }
 
+class GRN(tf.keras.layers.Layer):
+    """
+    Global Response Normalization layer
+    ConvNeXt V2: Co-designing and Scaling ConvNets with Masked Autoencoders (https://arxiv.org/abs/2301.00808)
+    https://github.com/facebookresearch/ConvNeXt-V2/blob/2553895753323c6fe0b2bf390683f5ea358a42b9/models/utils.py#L105
 
-def _add_convnext_block(inpt, **kwargs):
+    pytorch original:
+    def __init__(self, dim):
+        super().__init__()
+        self.gamma = nn.Parameter(torch.zeros(1, 1, 1, dim))
+        self.beta = nn.Parameter(torch.zeros(1, 1, 1, dim))
+
+    def forward(self, x):
+        Gx = torch.norm(x, p=2, dim=(1,2), keepdim=True)
+        Nx = Gx / (Gx.mean(dim=-1, keepdim=True) + 1e-6)
+        return self.gamma * (x * Nx) + self.beta + x
+
+    """
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def build(self, input_shape):
+        n_channels = input_shape[-1]
+        self.gamma = self.add_weight(
+            shape=(n_channels,),
+            initializer="zeros",
+            name="gamma",
+            trainable=True,
+        )
+        self.beta = self.add_weight(
+            shape=(n_channels,),
+            initializer="zeros",
+            name="beta",
+            trainable=True,
+        )
+
+    def call(self, inputs):
+        Gx = tf.norm(inputs, ord=2, axis=(1,2), keepdims=True)
+        Nx = Gx / (tf.reduce_mean(Gx, axis=-1, keepdims=True) + 1e-6) # CN2 code uses mean, paper seems to use sum
+        return self.gamma * (inputs * Nx) + self.beta + inputs
+
+    def get_config(self):
+        config = super().get_config()
+        return config
+
+
+def _add_convnext_block(inpt, use_grn, **kwargs):
     """
     
     """
@@ -29,12 +82,15 @@ def _add_convnext_block(inpt, **kwargs):
     
     x = tf.keras.layers.Conv2D(4*k0, 1)(x)
     x = tf.keras.layers.Activation(tf.nn.gelu)(x)
+
+    if use_grn:
+        x = GRN()(x)
     
     x = tf.keras.layers.Conv2D(k0,1)(x)
     return tf.keras.layers.Add(**kwargs)([inpt,x])
 
 
-def build_convnext_fcn(m, num_channels=3):
+def build_convnext_fcn(m, use_grn=False, num_channels=3):
     """
     :m: str; "T", "S", "B", "L", or "XL"
     """
@@ -49,7 +105,7 @@ def build_convnext_fcn(m, num_channels=3):
             kwargs = {}
         # add stage of convnext blocks
         for i in range(_blocks[m][stage]):
-            x = _add_convnext_block(x, **kwargs)
+            x = _add_convnext_block(x, use_grn, **kwargs)
         if stage < 3:
             # add downsampling layer
             x = tf.keras.layers.LayerNormalization()(x)

--- a/patchwork/_convnext.py
+++ b/patchwork/_convnext.py
@@ -3,27 +3,27 @@ import tensorflow as tf
 
 
 _channels = {
-    "A":(40, 80, 160, 320), #v2 atto
-    "F":(48, 96, 192, 384), #v2 femto
-    "P":(64, 128, 256, 512), #v2 pico
-    "N":(80, 160, 320, 640), #v2 nano
-    "T":(96, 192, 384, 768),
+    "A": (40, 80, 160, 320),  # v2 atto
+    "F": (48, 96, 192, 384),  # v2 femto
+    "P": (64, 128, 256, 512),  # v2 pico
+    "N": (80, 160, 320, 640),  # v2 nano
+    "T": (96, 192, 384, 768),
     "S": (96, 192, 384, 768),
-    "B":(128, 256, 512, 1024),
-    "L":(192, 384, 768, 1536),
-    "XL":(256, 512, 1024, 2048)
+    "B": (128, 256, 512, 1024),
+    "L": (192, 384, 768, 1536),
+    "XL": (256, 512, 1024, 2048)
 }
 
 _blocks = {
-    "A":(2, 2, 6, 2),
-    "F":(2, 2, 6, 2),
-    "P":(2, 2, 6, 2),
-    "N":(2, 2, 8, 2),
-    "T":(3, 3, 9, 3),
-    "S":(3, 3, 27, 3),
-    "B":(3, 3, 27, 3),
-    "L":(3, 3, 27, 3),
-    "XL":(3, 3, 27, 3)
+    "A": (2, 2, 6, 2),
+    "F": (2, 2, 6, 2),
+    "P": (2, 2, 6, 2),
+    "N": (2, 2, 8, 2),
+    "T": (3, 3, 9, 3),
+    "S": (3, 3, 27, 3),
+    "B": (3, 3, 27, 3),
+    "L": (3, 3, 27, 3),
+    "XL": (3, 3, 27, 3)
 }
 
 
@@ -38,6 +38,7 @@ class LayerScale(tf.keras.layers.Layer):
     def __init__(self, init_value, **kwargs):
         super().__init__(**kwargs)
         self.init_value = init_value
+
 
     def build(self, input_shape):
         n_channels = input_shape[-1]
@@ -112,13 +113,13 @@ def _add_convnext_block(inpt, use_grn=False, **kwargs):
     k0 = inpt.shape[-1]
     x = tf.keras.layers.DepthwiseConv2D(7, padding="same")(inpt)
     x = tf.keras.layers.LayerNormalization()(x)
-    
+
     x = tf.keras.layers.Conv2D(4*k0, 1)(x)
     x = tf.keras.layers.Activation(tf.nn.gelu)(x)
 
     if use_grn:
         x = GRN()(x)
-    
+
     x = tf.keras.layers.Conv2D(k0,1)(x)
     return tf.keras.layers.Add(**kwargs)([inpt,x])
 
@@ -130,18 +131,18 @@ def build_convnext_fcn(m, use_grn=False, num_channels=3):
     inpt = tf.keras.layers.Input((None, None, num_channels))
     x = tf.keras.layers.Conv2D(_channels[m][0], 4, strides=4)(inpt)
     x = tf.keras.layers.LayerNormalization()(x)
-    
+
     for stage in range(4):
         if stage == 3:
-            kwargs = {"dtype":"float32"}
+            kwargs = {"dtype": "float32"}
         else:
             kwargs = {}
         # add stage of convnext blocks
-        for i in range(_blocks[m][stage]):
+        for _ in range(_blocks[m][stage]):
             x = _add_convnext_block(x, use_grn, **kwargs)
         if stage < 3:
             # add downsampling layer
             x = tf.keras.layers.LayerNormalization()(x)
             x = tf.keras.layers.Conv2D(_channels[m][stage+1], 2, strides=2)(x)
-        
+
     return tf.keras.Model(inpt, x)

--- a/patchwork/_convnext.py
+++ b/patchwork/_convnext.py
@@ -117,7 +117,6 @@ def _add_convnext_block(inpt, use_grn=False, **kwargs):
     x = tf.keras.layers.Activation(tf.nn.gelu)(x)
 
     if use_grn:
-        #x = LayerScale(1e-6)(x)
         x = GRN()(x)
     
     x = tf.keras.layers.Conv2D(k0,1)(x)

--- a/patchwork/tests/test_convnext.py
+++ b/patchwork/tests/test_convnext.py
@@ -1,9 +1,31 @@
 # -*- coding: utf-8 -*-
 
 import tensorflow as tf
+import numpy as np
+from tensorflow.python.framework import random_seed
+random_seed.set_seed(42)
 
-from patchwork._convnext import _add_convnext_block
+from patchwork._convnext import _add_convnext_block, build_convnext_fcn
 
+
+def test_build_convnext():
+    x = tf.ones((1, 224, 224, 3))
+    fcn = build_convnext_fcn("T", use_grn=True, num_channels=3)
+    print(fcn(x).shape)
+    assert fcn(x).shape == (1, 7, 7, 768)
+
+    
+def test_convnext_grn():
+    tf.config.experimental.enable_op_determinism()
+    x = tf.random.uniform((1, 224, 224, 1))
+    tf.keras.utils.set_random_seed(1)
+    fcn_nogrn = build_convnext_fcn("T", use_grn=False, num_channels=1)
+    tf.keras.utils.set_random_seed(1)
+    fcn_grn = build_convnext_fcn("T", use_grn=True, num_channels=1)
+    nogrn_out = fcn_nogrn(x)
+    grn_out = fcn_grn(x)
+    assert np.array_equal(nogrn_out.numpy(), grn_out.numpy())
+    
 
 def test_add_convnext_block():
     inpt = tf.keras.layers.Input((11, 13, 7))

--- a/patchwork/tests/test_convnext.py
+++ b/patchwork/tests/test_convnext.py
@@ -7,13 +7,20 @@ from patchwork._convnext import _add_convnext_block, build_convnext_fcn
 
 
 def test_build_convnext():
+    """
+    checks that we get the expected output shape
+    """
     x = tf.ones((1, 224, 224, 3))
     fcn = build_convnext_fcn("T", use_grn=True, num_channels=3)
     print(fcn(x).shape)
     assert fcn(x).shape == (1, 7, 7, 768)
 
-    
+
 def test_convnext_grn():
+    """
+    runs the same input with and without GRN and checks that
+    the result is the same
+    """
     tf.config.experimental.enable_op_determinism()
     x = tf.random.uniform((1, 224, 224, 1))
     tf.keras.utils.set_random_seed(1)
@@ -23,7 +30,7 @@ def test_convnext_grn():
     nogrn_out = fcn_nogrn(x)
     grn_out = fcn_grn(x)
     assert np.array_equal(nogrn_out.numpy(), grn_out.numpy())
-    
+
 
 def test_add_convnext_block():
     inpt = tf.keras.layers.Input((11, 13, 7))

--- a/patchwork/tests/test_convnext.py
+++ b/patchwork/tests/test_convnext.py
@@ -2,8 +2,6 @@
 
 import tensorflow as tf
 import numpy as np
-from tensorflow.python.framework import random_seed
-random_seed.set_seed(42)
 
 from patchwork._convnext import _add_convnext_block, build_convnext_fcn
 

--- a/patchwork/viz/_projector.py
+++ b/patchwork/viz/_projector.py
@@ -28,7 +28,7 @@ def _make_sprite(images, spritesize=50):
     """
     num_sprites = images.shape[0]
     imsize = images.shape[1]
-    gridsize = np.int(np.ceil(np.sqrt(num_sprites)))
+    gridsize = int(np.ceil(np.sqrt(num_sprites)))
     output = np.zeros((imsize*gridsize, imsize*gridsize, 3), dtype=np.uint8)
 
     for i in range(num_sprites):


### PR DESCRIPTION
I added GRN to the _convnext module. It's from this paper:

    ConvNeXt V2: Co-designing and Scaling ConvNets with Masked Autoencoders (https://arxiv.org/abs/2301.00808)

Note that they did a bunch of other stuff in this paper - self-supervised learning using masked convolutions -- but I didn't implement any of that.

Unless I missed something, the current version of _convnext.py does not include layer scaling from the original paper. Not sure how important this is, but they say it isn't necessary with GRN in V2.

I also fixed a couple of deprecated numpy dtype casting function calls (np.int and np.bool are deprecated in favor of plain int and bool).

I took a bit of a "pirates code" approach to the contribution guidlines but did at least add some perfunctory tests for the new layer. Feel free to kick it back to me for revision if you don't take this kind of crap here.