### PR TITLE
Histeq

### DIFF
--- a/patchwork/_labeler.py
+++ b/patchwork/_labeler.py
@@ -7,6 +7,7 @@ GUI code for training a model
 
 """
 import numpy as np
+import skimage.exposure
 import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle
 import panel as pn
@@ -114,7 +115,10 @@ class ButtonPanel(object):
         
         self.label_counts = pn.pane.Markdown("")
         
+        self._exposure = pn.widgets.Toggle(name="histeq", button_type="default", value=True, width=50)
         self._button_panel = pn.Column(pn.Spacer(height=50),
+                                        pn.pane.Markdown("## Display"),
+                                        self._exposure,
                                        pn.pane.Markdown("## Image labels"),
                                         self._exclude, 
                                         self._validation,
@@ -149,6 +153,10 @@ class ButtonPanel(object):
         filepaths = self._df["filepath"].iloc[indices]
         # load to numpy arrays
         self._image_arrays = [self._load_func(f) for f in filepaths]
+        if self._exposure.value:
+            for idx in range(len(self._image_arrays)):
+                self._image_arrays[idx] = skimage.exposure.equalize_adapthist(self._image_arrays[idx])
+
         # make a list of matplotlib figures, one for each image that
         # could be highlighted
         self._figs = _gen_figs(self._image_arrays, dim=self.dim, lw=5)

--- a/patchwork/_labeler.py
+++ b/patchwork/_labeler.py
@@ -54,7 +54,10 @@ def _gen_figs(arrays, dim=3, lw=5):
         figs.append(fig)
     return figs
 
-
+def _dummy_fig():
+    fig = plt.figure(figsize=(6,6))
+    fig.text(0.25, 0.25, 'temporary figure')
+    return fig
 
 def _single_class_radiobuttons(width=125, height=25):
     """
@@ -86,7 +89,7 @@ class ButtonPanel(object):
         self.dim = dim
         self._num_images = dim**2
 
-        self._figpanel = pn.pane.Matplotlib(height_policy="fit",
+        self._figpanel = pn.pane.Matplotlib(_dummy_fig(), height_policy="fit",
                                             width_policy="fit",
                                             aspect_ratio=1,
                                             width=size, height=size)

--- a/patchwork/tests/test_convnext.py
+++ b/patchwork/tests/test_convnext.py
@@ -16,20 +16,20 @@ def test_build_convnext():
     assert fcn(x).shape == (1, 7, 7, 768)
 
 
-def test_convnext_grn():
-    """
-    runs the same input with and without GRN and checks that
-    the result is the same
-    """
-    tf.config.experimental.enable_op_determinism()
-    x = tf.random.uniform((1, 224, 224, 1))
-    tf.keras.utils.set_random_seed(1)
-    fcn_nogrn = build_convnext_fcn("T", use_grn=False, num_channels=1)
-    tf.keras.utils.set_random_seed(1)
-    fcn_grn = build_convnext_fcn("T", use_grn=True, num_channels=1)
-    nogrn_out = fcn_nogrn(x)
-    grn_out = fcn_grn(x)
-    assert np.array_equal(nogrn_out.numpy(), grn_out.numpy())
+# def test_convnext_grn():
+#     """
+#     runs the same input with and without GRN and checks that
+#     the result is the same
+#     """
+#     tf.config.experimental.enable_op_determinism()
+#     x = tf.random.uniform((1, 224, 224, 1))
+#     tf.keras.utils.set_random_seed(1)
+#     fcn_nogrn = build_convnext_fcn("T", use_grn=False, num_channels=1)
+#     tf.keras.utils.set_random_seed(1)
+#     fcn_grn = build_convnext_fcn("T", use_grn=True, num_channels=1)
+#     nogrn_out = fcn_nogrn(x)
+#     grn_out = fcn_grn(x)
+#     assert np.array_equal(nogrn_out.numpy(), grn_out.numpy())
 
 
 def test_add_convnext_block():


### PR DESCRIPTION
I definitely broke many tests with  my last pull request by using enable_op_determinism in test_convnext. That caused any other tests that used random numbers but didn't set a seed to throw errors. I've commented out the new test for now to avoid that. At some point in my development I stopped running all the tests, only the convnext ones because I thought I wouldn't affect the others. Clearly that didn't work out.

Besides that, this pull request:
 - fixes an error I was getting where the Matplotlib panel in the Labeler UI might not have a figure at first, causing it to die
 - adds the option to do adaptive histogram equalization for the images in the Labeler UI which can make things easier to see